### PR TITLE
Fix MacOS build

### DIFF
--- a/h-raylib.cabal
+++ b/h-raylib.cabal
@@ -221,6 +221,7 @@ library
     c-sources:
       lib/rglfw.m
       lib/rl_bindings.c
+      lib/rl_internal.c
       raylib/src/raudio.c
       raylib/src/rcore.c
       raylib/src/rmodels.c


### PR DESCRIPTION
MacOS builds fail due to missing symbols for _UnloadAudioBuffer_. This is fixed by adding rl_internal.c to the cabal c-sources for MacOS builds. It seems like this was meant to be there already.