### PR TITLE
Release lens bounds

### DIFF
--- a/h-raylib.cabal
+++ b/h-raylib.cabal
@@ -172,7 +172,7 @@ library
     , base        >=4.0    && <4.19
     , containers  >=0.6.0  && <0.6.7.0
     , exceptions  >=0.10.4 && <0.10.8
-    , lens        >=4.0    && <5.2.2.0
+    , lens        >=4.0    && <5.2.3.0
 
   hs-source-dirs:   src
   default-language: Haskell2010


### PR DESCRIPTION
Release lens version 5.2.3 bounds
There is no breaking change in lens. https://hackage.haskell.org/package/lens-5.2.3/changelog
Bound should be release in order to work with newest lens pkgs